### PR TITLE
implement showcases section

### DIFF
--- a/hugo/data/home/home.yml
+++ b/hugo/data/home/home.yml
@@ -23,17 +23,17 @@ roadmap:
   - Ad id nulla consectetur occaecat duis est pariatur. Sunt anim id cillum aliqua enim id ea sit sunt voluptate dolor labore mollit. Excepteur nulla qui minim voluptate ea. Eu ullamco consectetur voluptate amet commodo mollit esse cillum ullamco.
   - Ad id nulla consectetur occaecat duis est pariatur. Sunt anim id cillum aliqua enim id ea sit sunt voluptate dolor labore mollit. Excepteur nulla qui minim voluptate ea. Eu ullamco consectetur voluptate amet commodo mollit esse cillum ullamco.
 
-projects_carousel:
+showcases:
   display: true
 
-our_categories:
+projects:
   display: true
 
-our_roadmap:
+roadmap:
   display: true
 
 testimonials:
   display: true
 
-our_posts:
+posts:
   display: true

--- a/hugo/layouts/index.html
+++ b/hugo/layouts/index.html
@@ -1,21 +1,21 @@
 {{ partial "head.html" . }}
 {{ $home := $.Site.Data.home.home }}
+{{ $showcases := $.Site.Data.home.showcases }}
 
 <body class="homePage">
     {{ partial "header.html" . }}
 
     {{ partial "home/hero.html" $home }}
 
-
-    {{ if $home.projects_carousel.display }}
-        {{ partial "home/showcases.html" . }}
+    {{ if $home.showcases.display }}
+        {{ partial "home/showcases.html" $showcases }}
     {{ end }}
 
-    {{ if $home.our_categories.display }}
+    {{ if $home.projects.display }}
         {{ partial "home/categories.html" . }}
     {{ end }}
 
-    {{ if $home.our_roadmap.display }}
+    {{ if $home.roadmap.display }}
         {{ partial "home/roadmap.html" $home }}
     {{ end }}
 
@@ -23,7 +23,7 @@
         {{ partial "home/testimonials.html" . }}
     {{ end }}
 
-    {{ if $home.our_posts.display }}
+    {{ if $home.posts.display }}
         {{ partial "home/blog.html" . }}
     {{ end }}
 

--- a/hugo/layouts/partials/home/showcases.html
+++ b/hugo/layouts/partials/home/showcases.html
@@ -1,15 +1,45 @@
-<h1>Showcases</h1>
-{{ range $p := $.Site.Data.home.showcases.showcases }}
-    <div>
-        <h2>{{$p.title}}</h2>
-        <p>{{$p.desc}}</p>
-        <a href="{{ $p.link }}" target="_blank">check this project</a>
+<div class="showcases">
+    <div class="showcases__info">
+        <h1>Showcases</h1>
+        
+        {{ range $s := first 1 .showcases }}
+        <h2 id="showcase-title">{{ $s.title }}</h2>
+        {{ end }}
+
+        <div class="showcases__project">
+            {{ range $s := .showcases }}
+            <div>
+                <p>{{ $s.desc }}</p>
+
+                <a href="{{ $s.link }}" target="_blank" title="{{ $s.title }}" class="btn-pill">check this project</a>
+            </div>
+            {{ end }}
+        </div>
     </div>
-{{ end }}
-<div>
-    {{ range $p := $.Site.Data.index.showcases.showcases }}
-            <pre>
-                <code class="{{ $p.language }}">{{ readFile (print "hugo/data/code/" $p.code) }}</code>
-            </pre>
+
+    {{ range $s := (first 1 .showcases) }}
+    <div class="showcases__terminal">
+        <div class="showcases__terminal__header">
+            <div></div>
+            <div></div>
+            <div></div>
+        </div>
+
+        <div id="showcase-code" class="showcases__terminal__code">
+        <pre><code class="{{ $s.language }}">{{ readFile (print "hugo/data/code/" $s.code) }}</code></pre>
+        </div>
+    </div>
     {{ end }}
 </div>
+
+<script>
+    window.showcases = [
+        {{ range $s := .showcases }}
+        {
+            title: "{{ $s.title }}",
+            language: "{{ $s.language }}",
+            code: "{{ readFile (print "hugo/data/code/" $s.code) }}",
+        },
+        {{ end }}
+    ];
+</script>

--- a/hugo/layouts/partials/home/showcases.html
+++ b/hugo/layouts/partials/home/showcases.html
@@ -8,11 +8,11 @@
 
         <div class="showcases__project">
             {{ range $s := .showcases }}
-            <div>
-                <p>{{ $s.desc }}</p>
+                <div>
+                    <p>{{ $s.desc }}</p>
 
-                <a href="{{ $s.link }}" target="_blank" title="{{ $s.title }}" class="btn-pill">check this project</a>
-            </div>
+                    <a href="{{ $s.link }}" target="_blank" title="{{ $s.title }}" class="btn-pill">check this project</a>
+                </div>
             {{ end }}
         </div>
     </div>
@@ -26,7 +26,9 @@
         </div>
 
         <div id="showcase-code" class="showcases__terminal__code">
-        <pre><code class="{{ $s.language }}">{{ readFile (print "hugo/data/code/" $s.code) }}</code></pre>
+            <pre><code class="{{ $s.language }}">
+                {{- readFile (print "hugo/data/code/" $s.code) -}}
+            </code></pre>
         </div>
     </div>
     {{ end }}
@@ -35,11 +37,11 @@
 <script>
     window.showcases = [
         {{ range $s := .showcases }}
-        {
-            title: "{{ $s.title }}",
-            language: "{{ $s.language }}",
-            code: "{{ readFile (print "hugo/data/code/" $s.code) }}",
-        },
+            {
+                title: "{{ $s.title }}",
+                language: "{{ $s.language }}",
+                code: "{{ readFile (print "hugo/data/code/" $s.code) }}",
+            },
         {{ end }}
     ];
 </script>

--- a/hugo/layouts/partials/home/showcases.html
+++ b/hugo/layouts/partials/home/showcases.html
@@ -1,4 +1,4 @@
-<div class="showcases">
+<section class="showcases">
     <div class="showcases__info">
         <h1>Showcases</h1>
         
@@ -17,7 +17,7 @@
         </div>
     </div>
 
-    {{ range $s := (first 1 .showcases) }}
+    {{ range $s := first 1 .showcases }}
     <div class="showcases__terminal">
         <div class="showcases__terminal__header">
             <div></div>
@@ -30,7 +30,7 @@
         </div>
     </div>
     {{ end }}
-</div>
+</section>
 
 <script>
     window.showcases = [

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,8 +4,8 @@ import ReactDOM from 'react-dom'
 import React from 'react'
 
 import $ from 'jquery'
+import 'slick-carousel'
 import hljs from 'highlight.js'
-import 'highlight.js/styles/atom-one-dark.css'
 import setupClipboard from './clipboard'
 import BlogPostsContainer from './components/Posts'
 import PositionsMain from './components/Positions'
@@ -22,13 +22,13 @@ function renderComponent(component, id) {
 }
 
 window.addEventListener('DOMContentLoaded', _ => {
-    setupMenu()
-    setupStickyHeader()
-    hljs.initHighlightingOnLoad()
-    renderComponent(BlogPostsContainer, 'ourPostsContainer')
-    renderComponent(PositionsMain, 'offersPanel')
-    renderComponent(SlackForm, 'slack-join')
-    setupClipboard()
+  setupMenu()
+  setupStickyHeader()
+  setupShowcases()
+  renderComponent(BlogPostsContainer, 'ourPostsContainer')
+  renderComponent(PositionsMain, 'offersPanel')
+  renderComponent(SlackForm, 'slack-join')
+  setupClipboard()
 })
 
 function setupStickyHeader() {
@@ -46,4 +46,35 @@ function checkTopbarOpacity(topBar, opaqueAtOffset) {
     } else {
         topBar.classList.remove('opaque')
     }
+}
+
+function setupShowcases() {
+  const showcase = $('.showcases__project')
+  const code = document.getElementById('showcase-code')
+  const title = document.getElementById('showcase-title')
+  showcase.slick({
+    dots: true,
+    infinite: true,
+    speed: 0,
+    fade: true,
+    swipe: false,
+    adaptiveHeight: true,
+  })
+
+  highlightCode(code)
+
+  showcase.on('beforeChange', function (e, slick, currentSlide, nextSlide) {
+    const project = window.showcases[nextSlide >= window.showcases.length ? 0 : nextSlide]
+    title.innerText = project.title
+    code.innerHTML = `
+    <pre><code class="${project.language}">${project.code}</code></pre>
+    `
+    highlightCode(code)
+  })
+}
+
+function highlightCode(code) {
+  if (code.children.length >= 0) {
+    hljs.highlightBlock(code.children[0])
+  }
 }

--- a/src/sass/pages/index.scss
+++ b/src/sass/pages/index.scss
@@ -1,7 +1,7 @@
 .home-hero {
   @include corporate-gradient;
   color: $color-hero-text;
-  padding: $padding-hero-vertical 0;
+  padding: $padding-section-vertical 0;
 
   &__wrap {
     @include row;
@@ -33,5 +33,124 @@
     background-color: $color-slack-form-bg;
     padding: $padding-slack-form;
     border-radius: 3px;
+  }
+}
+
+.showcases {
+  @include row;
+  @include container;
+  padding: $padding-section-vertical 0;
+
+  &__project {
+    padding-bottom: $padding-showcases-project-bottom;
+  }
+
+  &__info {
+    @include columns(4);
+
+    h1 {
+      @include default-title-big;
+    }
+
+    h2 {
+      @include default-title-medium;
+      margin-top: $margin-showcases-title-medium-top;
+    }
+
+    p {
+      padding: $padding-showcases-desc-vertical 0;
+    }
+
+    .slick-arrow {
+      display: none;
+    }
+
+    .slick-slide,
+    .slick-slide * {
+      outline: none;
+
+      // this is a hack so the shadow of the pills can be displayed inside slick
+      // since slick needs an overflow: hidden and the pill shadow is cut
+      .btn-pill {
+        margin-bottom: 5px;
+        margin-left: 5px;
+      }
+    }
+
+    .slick-dots {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      li {
+        height: $size-showcases-dot;
+        width: $size-showcases-dot;
+        border: $size-showcases-dot-border solid $color-showcases-dot-border;
+        border-radius: 50%;
+        padding: 0;
+        margin: 0;
+
+        button:before {
+          display: none;
+        }
+
+        &.slick-active {
+          background-color: $color-showcases-dot;
+          border: none;
+        }
+      }
+
+      li + li {
+        margin-left: $size-showcases-dot-spacing;
+      }
+    }
+  }
+
+  &__terminal {
+    @include columns(6);
+    border-radius: 5px;
+    overflow: hidden;
+
+    &__header {
+      background-color: $color-terminal-header-bg;
+      padding: $padding-terminal-header-vertical $padding-terminal-header-horizontal;
+
+      div {
+        height: $size-terminal-header-btn;
+        width: $size-terminal-header-btn;
+        background-color: $color-terminal-header-btn-bg;
+        border-radius: 50%;
+        display: inline-block;
+      }
+
+      div + div {
+        margin-left: $size-terminal-header-btn-spacing;
+      }
+    }
+
+    &__code {
+      overflow: auto;
+
+      pre {
+        background: $color-terminal-code-bg;
+        font-family: $font-source-code;
+        font-size: $font-size-terminal-source-code;
+        line-height: 1.25em;
+        padding: 1em;
+        color: $color-terminal-text;
+
+        .hljs-keyword {
+          color: $color-terminal-keyword;
+        }
+
+        .hljs-built_in, .hljs-params {
+          color: $color-terminal-special;
+        }
+
+        .hljs-string, .hljs-number {
+          color: $color-terminal-literals;
+        }
+      }
+    }
   }
 }

--- a/src/sass/shared/grid.scss
+++ b/src/sass/shared/grid.scss
@@ -13,11 +13,19 @@
 }
 
 @mixin width($num) {
-  width: ($column-size * $num) + ($gutter-size * ($num - 1));
+  width: grid-size($num);
+}
+
+@function grid-size($num) {
+  @return ($column-size * $num) + ($gutter-size * ($num - 1));
+}
+
+@function grid-offset-size($num) {
+  @return ($column-size * $num) + ($gutter-size * $num - 1);
 }
 
 @mixin offset($num) {
-  margin-left: ($column-size * $num) + ($gutter-size * $num) !important;
+  margin-left: grid-offset-size($num);
 }
 
 @mixin row() {

--- a/src/sass/shared/mixins.scss
+++ b/src/sass/shared/mixins.scss
@@ -33,14 +33,46 @@
   box-shadow: 3px 3px 5px rgba(0, 0, 0, .1);
 }
 
-@mixin title-big() {
-  font-size: $font-size-title-big;
+@mixin title($size) {
+  font-size: $size; 
   line-height: 1.2em;
   text-transform: lowercase;
+}
+
+@mixin title-big() {
+  @include title($font-size-title-big);
 }
 
 @mixin svg-color($icon, $color) {
   .svg-icon--#{$icon} path {
     fill: $color;
   }
+}
+
+@mixin title-pill($color, $width, $height, $spacing) {
+  position: relative;
+  
+  &:before {
+    position: absolute;
+    content: " ";
+    display: block;
+    border-radius: 45px;
+    height: $height;
+    width: $width;
+    left: -($width + $spacing);
+    top: calc(50% - #{$height / 2});
+    background-color: $color;
+  }
+}
+
+@mixin default-title-big() {
+  @include title-big;
+  color: $color-title-big;
+  @include title-pill($color-title-big-pill, $width-title-big-pill, $height-title-big-pill, $size-title-big-pill-spacing);
+}
+
+@mixin default-title-medium() {
+  @include title($font-size-title-medium);
+  color: $color-title-medium;
+  @include title-pill($color-title-medium-pill, $width-title-medium-pill, $height-title-medium-pill, $size-title-medium-pill-spacing);
 }

--- a/src/sass/shared/reset.scss
+++ b/src/sass/shared/reset.scss
@@ -85,3 +85,4 @@ iframe {
 *:after {
     box-sizing: border-box;
 }
+

--- a/src/sass/shared/variables.scss
+++ b/src/sass/shared/variables.scss
@@ -15,6 +15,12 @@ $color-links-darkbg-hover: $color-pale-grey;
 $color-hero-bg: $color-dark-blue;
 $color-hero-text: $color-white;
 
+$color-title-big: $color-light-blue;
+$color-title-big-pill: $color-light-blue;
+
+$color-title-medium: $color-dark-blue;
+$color-title-medium-pill: #ADB6BF;
+
 $color-slack-form-bg: $color-white;
 
 $color-pill-button-text: $color-light-blue;
@@ -28,7 +34,18 @@ $color-pill-button-white-hover-text: $color-dark-blue;
 $color-pill-button-white-hover-bg: $color-white;
 $color-pill-button-white-hover-shadow: rgba(60,118,159,1);
 
+$color-terminal-bg: #2D4861;
+$color-terminal-header-bg: $color-medium-grey;
+$color-terminal-header-btn-bg: $color-dark-grey;
+$color-terminal-code-bg: #33526C;
 
+$color-terminal-text: #B7BFC7;
+$color-terminal-keyword: #C3D31B;
+$color-terminal-special: #e66cd7;
+$color-terminal-literals: #3EB1D0;
+
+$color-showcases-dot: $color-light-blue;
+$color-showcases-dot-border: $color-light-blue;
 // Text sizes
 $font-size-body: 20px;
 $font-size-menu: 24px;
@@ -40,6 +57,7 @@ $font-size-title-small: 24px;
 $font-size-footer-titles: 21px;
 $font-size-footer-text: 16px;
 $font-size-pill-button: 21px;
+$font-size-terminal-source-code: 14px;
 
 // Font families
 $font-roboto: 'Roboto', sans-serif;
@@ -57,11 +75,32 @@ $num-columns: 10;
 $padding-slack-form: 30px;
 
 $margin-hero-desc-vertical: 30px;
-$padding-hero-vertical: $column-size;
+$padding-section-vertical: $column-size;
 
 $padding-pill-button-sides: 60px;
+
+$padding-terminal-header-vertical: $gutter-size / 3;
+$padding-terminal-header-horizontal: $gutter-size / 2;
+
+$margin-showcases-title-medium-top: $gutter-size / 4;
+$padding-showcases-desc-vertical: $gutter-size;
+$padding-showcases-project-bottom: $gutter-size;
 
 // Heights and widths
 $height-pill-buttons: 45px;
 
+$height-title-big-pill: 15px;
+$width-title-big-pill: 90px;
+$size-title-big-pill-spacing: 15px;
+$height-title-medium-pill: 15px;
+$width-title-medium-pill: 30px;
+$size-title-medium-pill-spacing: 15px;
+
 $size-button-spacing: $gutter-size / 2;
+
+$size-terminal-header-btn: $gutter-size / 2;
+$size-terminal-header-btn-spacing: $gutter-size / 4;
+
+$size-showcases-dot: 15px;
+$size-showcases-dot-spacing: 10px;
+$size-showcases-dot-border: 3px;


### PR DESCRIPTION
![screenshot_2017-06-09_12 47 38](https://user-images.githubusercontent.com/1312023/26975687-2c0e7364-4d21-11e7-93cc-d505c0c7725e.png)

As you can see in my screenshot with a screen of 1280px of width the pills of the titles don't fit.
The black lines on the left are because of the screenshot (are the borders of my chrome window)

### Some explanations

* Why is the h2 title of the project outside the slider? Because slick needs a `overflow: hidden` to work and thus the pill does not show.
* Why does the "check this project" button have a left margin of 5px? Same reason as above but with the hover shadow (it can be fixed with CSS but the effect is gonna be the same and it has the drawback of being displayed everywhere as opposed to just here).

### Questions

* @Serabe does it need to have autoplay now that it's not a proper slider?
